### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [1.2.1] — 2026-04-20
+
+Patch release to fix the automated release pipeline.
+
+### Fixed
+
+- **Release workflow tag push** — `git push origin "${TAG_NAME}"` failed with
+  `src refspec matches more than one` when both the release branch and the new
+  tag shared the same name. Changed to `git push origin "refs/tags/${TAG_NAME}"`
+  to explicitly push the tag reference.
+
+---
+
 ## [1.2.0] — 2026-04-20
 
 Major feature release. WireKit now covers full-page composition: a 10-component

--- a/dist/wirekit.core.js
+++ b/dist/wirekit.core.js
@@ -1,4 +1,4 @@
-/*! WireKit Core v1.2.0 | MIT License | https://wirekit.app */
+/*! WireKit Core v1.2.1 | MIT License | https://wirekit.app */
 (()=>{function u(a){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:
   npm install chart.js
 And import it in your app.js:

--- a/dist/wirekit.css
+++ b/dist/wirekit.css
@@ -1,5 +1,5 @@
 /*!
- * WireKit CSS v1.2.0 — MIT License
+ * WireKit CSS v1.2.1 — MIT License
  * https://github.com/pushery/wirekit
  * https://wirekit.app
  *

--- a/dist/wirekit.esm.js
+++ b/dist/wirekit.esm.js
@@ -1,4 +1,4 @@
-/*! WireKit ESM v1.2.0 | MIT License | https://wirekit.app
+/*! WireKit ESM v1.2.1 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 function Vt(e){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:

--- a/dist/wirekit.js
+++ b/dist/wirekit.js
@@ -1,4 +1,4 @@
-/*! WireKit v1.2.0 | MIT License | https://wirekit.app
+/*! WireKit v1.2.1 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 (()=>{function Ve(t){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:


### PR DESCRIPTION

Patch release to fix the automated release pipeline.

### Fixed

- **Release workflow tag push** — `git push origin "${TAG_NAME}"` failed with
  `src refspec matches more than one` when both the release branch and the new
  tag shared the same name. Changed to `git push origin "refs/tags/${TAG_NAME}"`
  to explicitly push the tag reference.

---
