### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,33 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [1.6.1] — 2026-04-30
+
+Patch release covering five consumer-visible fixes plus a README restructure and badge expansion. No new API surface; no breaking changes; every component renders byte-identical to v1.6.0 unless its specific bug applied.
+
+### Fixed
+
+- **`prefers-reduced-motion: reduce` now actually honored on `<x-wirekit::reveal>` and `wk-animate-*` utilities (WCAG 2.3.3).** The component documentation and helper docblock claimed the OS-level reduced-motion preference was respected, but the global `@media (prefers-reduced-motion: reduce)` block in `dist/wirekit.css` only gated `[x-transition]` selectors — the 22 keyframe animations driving every preset ran at full speed regardless of user preference. The block now gates `[class*='wk-animate-']` as well, snapping `animation-duration` to `0.01ms` so reduced-motion users see an instant snap-to-final state. Behavior now matches the documented contract.
+
+- **Nested `<x-wirekit::list>` margins no longer accumulate inside typography wrappers.** When the component is rendered inside a consumer's `.prose` / `.docs-prose` / `@tailwindcss/typography` context, the wrapper's `<ol>` / `<ul>` / `<li>` rules injected `margin: 1em 0` onto every level — and the previous Tailwind-utility approach was too low-specificity to win the cascade. Nested lists looked progressively more spaced out at deeper levels regardless of the `spacing` prop. The component now ships with a `wk-list` marker class plus dedicated `wk-list-spacing-{none,sm,md}` rules in `dist/wirekit.css` whose doubled-class selectors win on specificity alone (no `!important`, so consumers can still override with even-higher-specificity rules when they explicitly need to). The `spacing` prop is now the single source of truth for inter-item vertical rhythm at every nesting depth.
+
+- **`bounce` and `spring` reveal presets — final state no longer fades back to invisible.** The `wk-bounce-in` and `wk-spring-in` keyframes declared `opacity: 1` only at the 50% / 60% peaks; the 70% and 100% frames left opacity unspecified. With `animation-fill-mode: both`, some browser implementations held opacity at 1 from the last specified frame, but others interpolated back toward the underlying inline `opacity: 0` after the animation settled — the element became visible briefly, then vanished. All four `bounce` / `spring` keyframe blocks now declare `opacity` at every frame, so the final-state behavior is browser-independent.
+
+- **Source-file comment cleanup.** PHP, Blade, and Alpine JS files in `src/`, `resources/views/`, and `resources/js/` no longer carry internal-only project terminology in their inline comments and strings. Consumer-facing source now uses consistent product-public language throughout. No functional changes to any component, command, or helper.
+
+- **`wirekit:generate-changelogs` sanitizer — broader pattern coverage.** The codegen's commit-subject sanitizer (`GenerateChangelogsCommand::sanitizeSubject()`) now strips a wider set of internal-only phrasing before writing per-component changelog entries, plus a verb-prefix early-return that drops bullets which would otherwise reduce to bare verb stubs (`fix:`, `security:`, etc.). See the method docblock for the exhaustive pattern list.
+
+### Changed
+
+- **`README.md` restructured from a comprehensive standalone reference to a concise getting-started overview.** Installation walkthrough, Quick Start example, and the browser-support table are retained on the GitHub landing page; extended component tables and the customisation reference now live at docs.wirekit.app where they're searchable and link-rich. Net effect: the README acts as a 30-second "what is this and how do I install it" landing page; docs.wirekit.app remains the authoritative reference for everything else.
+
+- **`README.md` badge row expanded from 3 to 11 badges across two visual rows.** Row 1 (project status): Packagist version, Total Downloads, GitHub Actions test status, MIT licence, GitHub Stars, component count. Row 2 (stack): PHP ≥ 8.4, Laravel 12+, Livewire 4+, Tailwind CSS v4, Alpine.js. The CI badge in particular gives evaluators an at-a-glance signal that the build is green on `main`. Component-count badge auto-validates against `ComponentRegistry` via a Pest sync guard so the displayed number can never drift from the actual registry size.
+
+---
+
 ## [1.6.0] — 2026-04-29
 
-Minor release covering a downstream field-test brief, the brief's deferred extensions, and a unified motion subsystem. Twelve chunks shipped together so the topic — fonts, doctor diagnostics, stat description options, and a real animation system — can be closed in one release. No breaking changes; every new flag, prop, opt-in surface defaults to off so v1.5.0 consumers see byte-identical output.
+Minor release covering font-installation flags, doctor-command token diagnostics, three new opt-in props on `<x-wirekit::stat>`, a complete motion subsystem with the new `<x-wirekit::reveal>` component, and supporting CLI helpers. No breaking changes; every new flag, prop, and opt-in surface defaults to off so v1.5.0 consumers see byte-identical output.
 
 ### Added
 
@@ -51,7 +75,7 @@ Minor release covering a downstream field-test brief, the brief's deferred exten
 
 - **`docs/cli.md`** documents all new install flags + the interactive mode + the new doctor token-alignment section + a cross-link to the dedicated `wirekit:doctor` reference page.
 
-- **`docs/animations.md` interactive preset gallery** — fifteen click-triggered preview blocks covering all eleven `<x-wirekit::reveal>` presets (fade, slide-up, slide-down, slide-left, slide-right, scale, zoom, flip, rotate, bounce, spring) plus a duration comparison row (fast / normal / slow). Each block uses `trigger="click"` so the animation re-fires on demand instead of waiting for scroll-into-view. Reduced-motion users see the final state immediately.
+- **`docs/animations.md` interactive preset gallery** — fourteen toggle-button preview blocks covering all eleven `<x-wirekit::reveal>` presets (fade, slide-up, slide-down, slide-left, slide-right, scale, zoom, flip, rotate, bounce, spring) plus a duration comparison row (fast / normal / slow). Each block has a button that toggles between the `-in` and `-out` variants on successive clicks; clicks during an animation are ignored until `animationend` fires. Reduced-motion users see the final state immediately.
 
 - **`docs/dependencies.md` bundle sizes refreshed** to reflect the v1.6.0 additions: full bundle now ~23 KB gzip (78 KB raw, +`wirekitAnimate` Alpine helper), core unchanged at ~2 KB gzip (8 KB raw), ESM ~23 KB gzip (76 KB raw). Verified via `gzip -c | wc -c`.
 
@@ -69,7 +93,7 @@ Minor release covering a downstream field-test brief, the brief's deferred exten
 
 ## [1.5.0] — 2026-04-28
 
-Minor release covering a consumer-polish wave from real-world field-testing on a downstream landing-page build. Eight items in scope: a code-block screen-reader announcement fix, a `wirekit:doctor` post-build CSS sanity check, a hero-row `xl` size on `<x-wirekit::feature>`, a counter-animation `animate` prop on `<x-wirekit::stat>`, an `asideWidth` ratio refinement on `<x-wirekit::hero>`, eight new marketing-copy semantic aliases on `heroicons-marketing`, plus the syntax-highlighter contract documented in `docs/theming.md`.
+Minor release with eight consumer-facing improvements: a code-block screen-reader announcement fix, a `wirekit:doctor` post-build CSS sanity check, a hero-row `xl` size on `<x-wirekit::feature>`, a counter-animation `animate` prop on `<x-wirekit::stat>`, an `asideWidth` ratio refinement on `<x-wirekit::hero>`, eight new marketing-copy semantic aliases on `heroicons-marketing`, plus the syntax-highlighter contract documented in `docs/theming.md`.
 
 No breaking changes — fully backward-compatible with v1.4.0.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,24 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/pushery/wirekit.svg)](https://packagist.org/packages/pushery/wirekit)
 [![Total Downloads](https://img.shields.io/packagist/dt/pushery/wirekit.svg)](https://packagist.org/packages/pushery/wirekit)
+[![Tests](https://github.com/pushery/wirekit/actions/workflows/tests.yml/badge.svg)](https://github.com/pushery/wirekit/actions/workflows/tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![GitHub Stars](https://img.shields.io/github/stars/pushery/wirekit?style=flat&logo=github)](https://github.com/pushery/wirekit/stargazers)
+[![Components](https://img.shields.io/badge/components-110-5046e5)](https://docs.wirekit.app/components)
+
+[![PHP ≥ 8.4](https://img.shields.io/packagist/dependency-v/pushery/wirekit/php?logo=php&logoColor=white&color=777BB4&label=PHP)](https://www.php.net)
+[![Laravel 12+](https://img.shields.io/badge/Laravel-12+-FF2D20?logo=laravel&logoColor=white)](https://laravel.com)
+[![Livewire 4+](https://img.shields.io/badge/Livewire-4+-FB70A9?logo=livewire&logoColor=white)](https://livewire.laravel.com)
+[![Tailwind CSS v4](https://img.shields.io/badge/Tailwind-v4-06B6D4?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
+[![Alpine.js](https://img.shields.io/badge/Alpine.js-%E2%9C%93-8BC0D0?logo=alpinedotjs&logoColor=white)](https://alpinejs.dev)
 
 A free, open-source UI component library for **Laravel Livewire** — build app dashboards and marketing pages with **Tailwind CSS v4** and **Alpine.js**, zero utility-class soup.
 
-## Requirements  
+**110 components** across forms, navigation, overlays, layout, marketing, data display, and more — fully themeable, accessible by default, and dark-mode aware.
+
+→ **Full documentation: [docs.wirekit.app](https://docs.wirekit.app)**
+
+## Requirements
 
 - PHP 8.4+
 - Laravel 12+
@@ -29,7 +42,7 @@ WireKit's supported-browser baseline is **pinned to [Tailwind CSS v4's official 
 | **Safari** | 16.4 | March 2023 |
 | **Firefox** | 128 | July 2024 |
 
-Older browsers are out of scope: WireKit ships no polyfills, no vendor-prefix fallbacks, and no shims for dropped browsers. Users on older versions will see degraded or broken rendering. If your audience still needs legacy support, WireKit is not the right fit.
+Older browsers are out of scope: WireKit ships no polyfills, no vendor-prefix fallbacks, and no shims for dropped browsers.
 
 ## Installation
 
@@ -37,7 +50,7 @@ Older browsers are out of scope: WireKit ships no polyfills, no vendor-prefix fa
 composer require pushery/wirekit
 ```
 
-Add to your layout:
+Add the directives to your layout:
 
 ```blade
 <head>
@@ -57,188 +70,7 @@ Add WireKit's Blade source path to your `resources/css/app.css`:
 @source '../../vendor/pushery/wirekit/resources/views/**/*.blade.php';
 ```
 
-## Components
-
-### Form Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Button | `<x-wirekit::button>` | [Docs](https://docs.wirekit.app/components/button) |
-| Input | `<x-wirekit::input>` | [Docs](https://docs.wirekit.app/components/input) |
-| Label | `<x-wirekit::label>` | [Docs](https://docs.wirekit.app/components/label) |
-| Select | `<x-wirekit::select>` | [Docs](https://docs.wirekit.app/components/select) |
-| Textarea | `<x-wirekit::textarea>` | [Docs](https://docs.wirekit.app/components/textarea) |
-| Checkbox | `<x-wirekit::checkbox>` | [Docs](https://docs.wirekit.app/components/checkbox) |
-| Radio | `<x-wirekit::radio>` | [Docs](https://docs.wirekit.app/components/radio) |
-| Toggle | `<x-wirekit::toggle>` | [Docs](https://docs.wirekit.app/components/toggle) |
-| Date Picker | `<x-wirekit::date-picker>` | [Docs](https://docs.wirekit.app/components/date-picker) |
-| File Upload | `<x-wirekit::file-upload>` | [Docs](https://docs.wirekit.app/components/file-upload) |
-| Combobox | `<x-wirekit::combobox>` | [Docs](https://docs.wirekit.app/components/combobox) |
-| Slider | `<x-wirekit::slider>` | [Docs](https://docs.wirekit.app/components/slider) |
-| Color Picker | `<x-wirekit::color-picker>` | [Docs](https://docs.wirekit.app/components/color-picker) |
-| Field | `<x-wirekit::field>` | [Docs](https://docs.wirekit.app/components/field) |
-| Number Input | `<x-wirekit::number-input>` | [Docs](https://docs.wirekit.app/components/number-input) |
-| Password Input | `<x-wirekit::password-input>` | [Docs](https://docs.wirekit.app/components/password-input) |
-| OTP Input | `<x-wirekit::otp-input>` | [Docs](https://docs.wirekit.app/components/otp-input) |
-| Multi-Select | `<x-wirekit::multi-select>` | [Docs](https://docs.wirekit.app/components/multi-select) |
-| Tags Input | `<x-wirekit::tags-input>` | [Docs](https://docs.wirekit.app/components/tags-input) |
-| Rating | `<x-wirekit::rating>` | [Docs](https://docs.wirekit.app/components/rating) |
-| Segmented Control | `<x-wirekit::segmented-control>` | [Docs](https://docs.wirekit.app/components/segmented-control) |
-| Range Slider | `<x-wirekit::range-slider>` | [Docs](https://docs.wirekit.app/components/range-slider) |
-| Time Picker | `<x-wirekit::time-picker>` | [Docs](https://docs.wirekit.app/components/time-picker) |
-
-### Display Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Badge | `<x-wirekit::badge>` | [Docs](https://docs.wirekit.app/components/badge) |
-| Card | `<x-wirekit::card>` | [Docs](https://docs.wirekit.app/components/card) |
-| Avatar | `<x-wirekit::avatar>` | [Docs](https://docs.wirekit.app/components/avatar) |
-| Alert | `<x-wirekit::alert>` | [Docs](https://docs.wirekit.app/components/alert) |
-| Callout | `<x-wirekit::callout>` | [Docs](https://docs.wirekit.app/components/callout) |
-| Image Compare | `<x-wirekit::image-compare>` | [Docs](https://docs.wirekit.app/components/image-compare) |
-| Reaction | `<x-wirekit::reaction>` | [Docs](https://docs.wirekit.app/components/reaction) |
-| Reveal | `<x-wirekit::reveal>` | [Docs](https://docs.wirekit.app/components/reveal) |
-| Message | `<x-wirekit::message>` | [Docs](https://docs.wirekit.app/components/message) |
-| Date Separator | `<x-wirekit::date-separator>` | [Docs](https://docs.wirekit.app/components/date-separator) |
-| Kanban | `<x-wirekit::kanban>` | [Docs](https://docs.wirekit.app/components/kanban) |
-| Kanban Column | `<x-wirekit::kanban-column>` | [Docs](https://docs.wirekit.app/components/kanban) |
-
-### Data Display Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Table | `<x-wirekit::table>` | [Docs](https://docs.wirekit.app/components/table) |
-| Pagination | `<x-wirekit::pagination>` | [Docs](https://docs.wirekit.app/components/pagination) |
-| Empty State | `<x-wirekit::empty-state>` | [Docs](https://docs.wirekit.app/components/empty-state) |
-| Progress | `<x-wirekit::progress>` | [Docs](https://docs.wirekit.app/components/progress) |
-| Progress Circle | `<x-wirekit::progress.circle>` | [Docs](https://docs.wirekit.app/components/progress) |
-| Stat | `<x-wirekit::stat>` | [Docs](https://docs.wirekit.app/components/stat) |
-| Stats Group | `<x-wirekit::stats>` | [Docs](https://docs.wirekit.app/components/stat) |
-| Skeleton | `<x-wirekit::skeleton>` | [Docs](https://docs.wirekit.app/components/skeleton) |
-| Data List | `<x-wirekit::data-list>` | [Docs](https://docs.wirekit.app/components/data-list) |
-| Timeline | `<x-wirekit::timeline>` | [Docs](https://docs.wirekit.app/components/timeline) |
-| Tree View | `<x-wirekit::tree-view>` | [Docs](https://docs.wirekit.app/components/tree-view) |
-| Ticker | `<x-wirekit::ticker>` | [Docs](https://docs.wirekit.app/components/ticker) |
-| Price | `<x-wirekit::price>` | [Docs](https://docs.wirekit.app/components/price) |
-
-### Feedback Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Toast | `<x-wirekit::toast-region>` | [Docs](https://docs.wirekit.app/components/toast) |
-
-### Overlay Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Dropdown | `<x-wirekit::dropdown>` | [Docs](https://docs.wirekit.app/components/dropdown) |
-| Tooltip | `<x-wirekit::tooltip>` | [Docs](https://docs.wirekit.app/components/tooltip) |
-| Modal | `<x-wirekit::modal>` | [Docs](https://docs.wirekit.app/components/modal) |
-| Drawer | `<x-wirekit::drawer>` | [Docs](https://docs.wirekit.app/components/drawer) |
-| Hover Card | `<x-wirekit::hover-card>` | [Docs](https://docs.wirekit.app/components/hover-card) |
-| Popover | `<x-wirekit::popover>` | [Docs](https://docs.wirekit.app/components/popover) |
-| Context Menu | `<x-wirekit::context-menu>` | [Docs](https://docs.wirekit.app/components/context-menu) |
-| Alert Dialog | `<x-wirekit::alert-dialog>` | [Docs](https://docs.wirekit.app/components/alert-dialog) |
-| Command Palette | `<x-wirekit::command-palette>` | [Docs](https://docs.wirekit.app/components/command-palette) |
-
-### Navigation Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Tabs | `<x-wirekit::tabs>` | [Docs](https://docs.wirekit.app/components/tabs) |
-| Breadcrumb | `<x-wirekit::breadcrumb>` | [Docs](https://docs.wirekit.app/components/breadcrumb) |
-| Accordion | `<x-wirekit::accordion>` | [Docs](https://docs.wirekit.app/components/accordion) |
-| Sidebar | `<x-wirekit::sidebar>` | [Docs](https://docs.wirekit.app/components/sidebar) |
-| Stepper | `<x-wirekit::stepper>` | [Docs](https://docs.wirekit.app/components/stepper) |
-| Navbar | `<x-wirekit::navbar>` | [Docs](https://docs.wirekit.app/components/navbar) |
-| Menubar | `<x-wirekit::menubar>` | [Docs](https://docs.wirekit.app/components/menubar) |
-| Navigation Menu | `<x-wirekit::navigation-menu>` | [Docs](https://docs.wirekit.app/components/navigation-menu) |
-| Toolbar | `<x-wirekit::toolbar>` | [Docs](https://docs.wirekit.app/components/toolbar) |
-
-### Layout Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| App Shell | `<x-wirekit::app-shell>` | [Docs](https://docs.wirekit.app/components/app-shell) |
-| Header | `<x-wirekit::header>` | [Docs](https://docs.wirekit.app/components/header) |
-| Main | `<x-wirekit::main>` | [Docs](https://docs.wirekit.app/components/main) |
-| Brand | `<x-wirekit::brand>` | [Docs](https://docs.wirekit.app/components/brand) |
-| Profile | `<x-wirekit::profile>` | [Docs](https://docs.wirekit.app/components/profile) |
-| Container | `<x-wirekit::container>` | [Docs](https://docs.wirekit.app/components/container) |
-| Stack | `<x-wirekit::stack>` | [Docs](https://docs.wirekit.app/components/stack) |
-| Row | `<x-wirekit::row>` | [Docs](https://docs.wirekit.app/components/row) |
-| Grid | `<x-wirekit::grid>` | [Docs](https://docs.wirekit.app/components/grid) |
-| Section | `<x-wirekit::section>` | [Docs](https://docs.wirekit.app/components/section) |
-| Spacer | `<x-wirekit::spacer>` | [Docs](https://docs.wirekit.app/components/spacer) |
-| Divider | `<x-wirekit::divider>` | [Docs](https://docs.wirekit.app/components/divider) |
-| Center | `<x-wirekit::center>` | [Docs](https://docs.wirekit.app/components/center) |
-| Aspect Ratio | `<x-wirekit::aspect-ratio>` | [Docs](https://docs.wirekit.app/components/aspect-ratio) |
-| Visually Hidden | `<x-wirekit::visually-hidden>` | [Docs](https://docs.wirekit.app/components/visually-hidden) |
-
-### Typography Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Heading | `<x-wirekit::heading>` | [Docs](https://docs.wirekit.app/components/heading) |
-| Text | `<x-wirekit::text>` | [Docs](https://docs.wirekit.app/components/text) |
-| Link | `<x-wirekit::link>` | [Docs](https://docs.wirekit.app/components/link) |
-| Code | `<x-wirekit::code>` | [Docs](https://docs.wirekit.app/components/code) |
-| Code Block | `<x-wirekit::code-block>` | [Docs](https://docs.wirekit.app/components/code-block) |
-| Kbd | `<x-wirekit::kbd>` | [Docs](https://docs.wirekit.app/components/kbd) |
-| List | `<x-wirekit::list>` | [Docs](https://docs.wirekit.app/components/list) |
-| Blockquote | `<x-wirekit::blockquote>` | [Docs](https://docs.wirekit.app/components/blockquote) |
-| Mark | `<x-wirekit::mark>` | [Docs](https://docs.wirekit.app/components/mark) |
-| Highlight | `<x-wirekit::highlight>` | [Docs](https://docs.wirekit.app/components/highlight) |
-
-### Marketing Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Hero | `<x-wirekit::hero>` | [Docs](https://docs.wirekit.app/components/hero) |
-| Feature Grid | `<x-wirekit::feature-grid>` | [Docs](https://docs.wirekit.app/components/feature-grid) |
-| Feature | `<x-wirekit::feature>` | [Docs](https://docs.wirekit.app/components/feature) |
-| CTA | `<x-wirekit::cta>` | [Docs](https://docs.wirekit.app/components/cta) |
-| Footer | `<x-wirekit::footer>` | [Docs](https://docs.wirekit.app/components/footer) |
-
-### Utilities
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Fonts | `<x-wirekit::fonts>` | [Docs](https://docs.wirekit.app/components/fonts) |
-| Icon | `<x-wirekit::icon>` | [Docs](https://docs.wirekit.app/components/icon) |
-| Chart | `<x-wirekit-chart>` | [Docs](https://docs.wirekit.app/components/chart) |
-| Scroll Area | `<x-wirekit::scroll-area>` | [Docs](https://docs.wirekit.app/components/scroll-area) |
-| Scrollbar | `.wk-scrollbar` (CSS class) | [Docs](https://docs.wirekit.app/components/scrollbar) |
-| Scroll to Top | `<x-wirekit::scroll-to-top>` | [Docs](https://docs.wirekit.app/components/scroll-to-top) |
-| Structured Data | `<x-wirekit::structured-data>` | [Docs](https://docs.wirekit.app/components/structured-data) |
-
-### Specialized Components
-
-| Component | Tag | Docs |
-|-----------|-----|------|
-| Resizable | `<x-wirekit::resizable>` | [Docs](https://docs.wirekit.app/components/resizable) |
-| Carousel | `<x-wirekit::carousel>` | [Docs](https://docs.wirekit.app/components/carousel) |
-| Calendar | `<x-wirekit::calendar>` | [Docs](https://docs.wirekit.app/components/calendar) |
-| Tour | `<x-wirekit::tour>` | [Docs](https://docs.wirekit.app/components/tour) |
-| Clipboard Button | `<x-wirekit::clipboard-button>` | [Docs](https://docs.wirekit.app/components/clipboard-button) |
-| QR Code | `<x-wirekit::qr-code>` | [Docs](https://docs.wirekit.app/components/qr-code) |
-| Action Bar | `<x-wirekit::action-bar>` | [Docs](https://docs.wirekit.app/components/action-bar) |
-| Prose | `<x-wirekit::prose>` | [Docs](https://docs.wirekit.app/components/prose) |
-| Liquid Glass | `<x-wirekit::glass>` | [Docs](https://docs.wirekit.app/components/liquid-glass) |
-
-## Dependencies
-
-### Bundled in `dist/wirekit.js` (no user install needed)
-
-| Package | Version | License | Purpose | Size (gzip) |
-|---------|---------|---------|---------|-------------|
-| `@floating-ui/dom` | ^1.7.0 | MIT | Dropdown/Tooltip positioning | ~3.5 KB |
-| `@floating-ui/core` | ^1.7.0 | MIT | Positioning core (transitive) | ~2.5 KB |
-| `focus-trap` | ^8.0.0 | MIT | Modal/Drawer focus management | ~3.8 KB |
-| `tabbable` | ^6.0.0 | MIT | Focusable element detection (transitive) | ~1.5 KB |
-
-See the full [Dependencies page](https://docs.wirekit.app/dependencies) for all dependencies.
+Full setup walkthrough: **[Getting Started](https://docs.wirekit.app/getting-started)** · **[Integration Guide](https://docs.wirekit.app/integration)**
 
 ## Quick Start
 
@@ -257,125 +89,56 @@ See the full [Dependencies page](https://docs.wirekit.app/dependencies) for all 
 <x-wirekit::textarea label="Bio" name="bio" wire:model="bio" />
 ```
 
-## Font Presets
+## What's Included
 
-21 Google Fonts bundled locally (GDPR-compliant). Configure in `config/wirekit.php`:
+110 components organised into 11 categories. Browse, search, and try every component live on **[docs.wirekit.app/components](https://docs.wirekit.app/components)**.
 
-```php
-'fonts' => [
-    'sans'  => 'inter',
-    'mono'  => 'jetbrains-mono',
-],
-```
+| Category | Examples |
+|----------|----------|
+| **Forms** | button, input, select, textarea, combobox, multi-select, date-picker, slider, color-picker, otp-input, … |
+| **Display** | badge, card, avatar, alert, callout, image-compare, kanban, reveal, … |
+| **Data Display** | table, pagination, stat, progress, skeleton, timeline, tree-view, ticker, price, … |
+| **Overlays** | dropdown, tooltip, modal, drawer, popover, hover-card, command-palette, alert-dialog, … |
+| **Navigation** | tabs, breadcrumb, accordion, sidebar, navbar, menubar, navigation-menu, stepper, … |
+| **Layout** | app-shell, header, main, container, stack, grid, section, divider, … |
+| **Typography** | heading, text, link, code, code-block, kbd, list, blockquote, mark, … |
+| **Marketing** | hero, feature-grid, feature, cta, footer |
+| **Utilities** | fonts, icon, chart, scroll-area, scroll-to-top, structured-data |
+| **Specialized** | resizable, carousel, calendar, tour, qr-code, action-bar, prose, liquid-glass |
+| **Feedback** | toast |
 
-Then publish and include: `php artisan vendor:publish --tag=wirekit-fonts` + `<x-wirekit::fonts />` in your layout. See the [Theming Guide](https://docs.wirekit.app/theming#font-presets) for all available fonts.
+## Theming & Customization
 
-## Icon Presets
-
-Swap icon sets with one config change. 26 semantic aliases, four base presets (`heroicons`, `lucide`, `phosphor`, `tabler`) plus two stackable extension presets (`heroicons-app`, `heroicons-marketing`) that add app-state and marketing aliases on top of a base:
-
-```php
-// Single base preset
-'icons' => [
-    'preset' => 'heroicons',  // or 'lucide', 'phosphor', 'tabler'
-],
-
-// Or stack a base + one or both extensions
-'icons' => [
-    'presets' => ['heroicons', 'heroicons-app', 'heroicons-marketing'],
-],
-```
-
-Install your preferred icon set: `composer require blade-ui-kit/blade-icons blade-ui-kit/blade-heroicons`. See the [Icon docs](https://docs.wirekit.app/components/icon) for all aliases and custom presets.
-
-## Charts
-
-Optional chart integration with automatic WireKit theming. Dark mode updates automatically via MutationObserver — no page reload needed. Disabled by default.
-
-```php
-'charts' => ['library' => 'chartjs'],
-```
-
-```blade
-<x-wirekit-chart type="bar" :labels="$months" :datasets="$datasets" />
-```
-
-Install Chart.js: `npm install chart.js`. See the [Chart docs](https://docs.wirekit.app/components/chart) for all options and custom adapters.
-
-## Customization (4 Levels)
-
-WireKit provides a 4-level customization system — from simple theme changes to full component overrides.
-
-### Level 1: CSS Variables
-
-Override theme tokens in your `app.css` (cascades on top of `wirekit.css` loaded via `@wirekitStyles`):
+WireKit ships with a **4-level customization system** — from CSS-variable theme tokens to fully published Blade views. Every component reads from `--color-wk-*` design tokens with built-in dark-mode support.
 
 ```css
 @layer base {
     :root {
         --color-wk-accent: var(--color-blue-600);
-        --color-wk-accent-hover: var(--color-blue-700);
-        --color-wk-accent-fg: var(--color-white);
     }
 }
 ```
 
-### Level 2: PHP Defaults
+→ **[Theming Guide](https://docs.wirekit.app/theming)** · **[Customization Guide](https://docs.wirekit.app/customization)**
 
-Set default props globally in a service provider:
+## Optional Integrations
 
-```php
-WireKit::defaults([
-    'button' => ['variant' => 'outline', 'size' => 'sm'],
-    'input'  => ['size' => 'lg'],
-]);
-```
+- **Fonts** — 21 Google Fonts bundled locally (GDPR-compliant). Configure via `config/wirekit.php`.
+- **Icons** — Stackable presets for `heroicons`, `lucide`, `phosphor`, `tabler` plus app/marketing extensions. 26 semantic aliases.
+- **Charts** — Optional Chart.js integration with automatic WireKit theming and dark-mode reactivity.
 
-### Level 3: Deep Personalization
-
-Replace CSS classes entirely for any component block:
-
-```php
-WireKit::personalize('button', [
-    'base' => 'your-custom-classes-here',
-]);
-```
-
-### Level 4: Publish Views
-
-Full control — publish and edit the Blade templates directly:
-
-```bash
-php artisan vendor:publish --tag=wirekit-views
-```
-
-See the full [Customization Guide](https://docs.wirekit.app/customization) and [Theming Guide](https://docs.wirekit.app/theming) for details.
-
-## Recipes
-
-Focused composition snippets between full-page blueprints and full layouts. Each recipe is a 30–60 line preview demonstrating one pattern with copy-paste source code.
-
-| Recipe | Demonstrates |
-|--------|--------------|
-| [Stat with Sparkline](https://docs.wirekit.app/recipes/stat-with-sparkline) | Stat citation + sparkline named slots |
-| [Feature with Numbered Marker](https://docs.wirekit.app/recipes/feature-numbered-marker) | Feature `iconSlot` for custom step markers |
-| [Hero with Code Aside](https://docs.wirekit.app/recipes/hero-with-code-aside) | Hero `aside` slot + accessible code-block |
-| [Toolbar Filter Bar](https://docs.wirekit.app/recipes/toolbar-filter-bar) | Toolbar + filter selects + bulk actions |
-| [Live KPI Strip](https://docs.wirekit.app/recipes/live-kpi-strip) | Ticker + `wire:poll` auto-refresh |
+→ **[Theming Guide](https://docs.wirekit.app/theming)** for fonts and presets · **[Icon docs](https://docs.wirekit.app/components/icon)** · **[Chart docs](https://docs.wirekit.app/components/chart)**
 
 ## Documentation
 
-Full documentation is available at **[docs.wirekit.app](https://docs.wirekit.app)**.
-
-| Document | Description |
-|----------|-------------|
-| [Getting Started](https://docs.wirekit.app/getting-started) | Installation and first steps |
-| [Theming](https://docs.wirekit.app/theming) | CSS variable theming system |
-| [Customization](https://docs.wirekit.app/customization) | 4-level customization guide |
-| [CLI Reference](https://docs.wirekit.app/cli) | All ten `wirekit:*` Artisan commands |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution guidelines and component conventions |
-| [CHANGELOG.md](CHANGELOG.md) | Release history |
-| [LICENSE](LICENSE) | MIT License |
+| Resource | Where |
+|----------|-------|
+| Full documentation | [docs.wirekit.app](https://docs.wirekit.app) |
+| Component reference | [docs.wirekit.app/components](https://docs.wirekit.app/components) |
+| Recipes & blueprints | [docs.wirekit.app/recipes](https://docs.wirekit.app/recipes) |
+| CLI reference | [docs.wirekit.app/cli](https://docs.wirekit.app/cli) |
+| Contribution guide | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Release history | [CHANGELOG.md](CHANGELOG.md) |
 
 ## License
 

--- a/dist/wirekit.core.js
+++ b/dist/wirekit.core.js
@@ -1,4 +1,4 @@
-/*! WireKit Core v1.6.0 | MIT License | https://wirekit.app */
+/*! WireKit Core v1.6.1 | MIT License | https://wirekit.app */
 (()=>{function d(a){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:
   npm install chart.js
 And import it in your app.js:

--- a/dist/wirekit.css
+++ b/dist/wirekit.css
@@ -1,5 +1,5 @@
 /*!
- * WireKit CSS v1.6.0 — MIT License
+ * WireKit CSS v1.6.1 — MIT License
  * https://github.com/pushery/wirekit
  * https://wirekit.app
  *
@@ -468,22 +468,22 @@
 @keyframes wk-bounce-in {
     0%   { opacity: 0; transform: scale(0.3); }
     50%  { opacity: 1; transform: scale(1.05); }
-    70%  {              transform: scale(0.9); }
-    100% {              transform: scale(1); }
+    70%  { opacity: 1; transform: scale(0.9); }
+    100% { opacity: 1; transform: scale(1); }
 }
 @keyframes wk-bounce-out {
-    0%   {              transform: scale(1); }
-    20%  {              transform: scale(0.9); }
+    0%   { opacity: 1; transform: scale(1); }
+    20%  { opacity: 1; transform: scale(0.9); }
     100% { opacity: 0; transform: scale(1.1); }
 }
 
 @keyframes wk-spring-in {
     0%   { opacity: 0; transform: translateY(0.75rem) scale(0.95); }
     60%  { opacity: 1; transform: translateY(-0.25rem) scale(1.02); }
-    100% {              transform: translateY(0) scale(1); }
+    100% { opacity: 1; transform: translateY(0) scale(1); }
 }
 @keyframes wk-spring-out {
-    0%   {              transform: translateY(0) scale(1); }
+    0%   { opacity: 1; transform: translateY(0) scale(1); }
     100% { opacity: 0; transform: translateY(-0.5rem) scale(0.98); }
 }
 
@@ -888,6 +888,32 @@
     --wk-image-compare-handle-size: 2.5rem;
 }
 
+/* List component — neutralize consumer typography wrappers (`.prose`,      */
+/* `.docs-prose`, `@tailwindcss/typography`) that would otherwise inject    */
+/* margin onto nested `<ol>`/`<ul>`/`<li>` and compound across depth.       */
+/*                                                                          */
+/* Specificity strategy (no `!important`): every rule selector starts with  */
+/* `.wk-list.wk-list` — class doubling is a valid CSS pattern that adds an  */
+/* extra class slot to the selector specificity (0,2,X instead of 0,1,X).   */
+/* Typical typography rules cap out at 0,1,1 (`.prose ol`, `.prose li`), so */
+/* 0,2,1 always wins on equal element specificity. Source order between us */
+/* and the consumer becomes irrelevant — specificity carries the decision. */
+/*                                                                          */
+/* Why doubling instead of `!important`: `!important` is a sledgehammer that*/
+/* the consumer can't override even when they explicitly need to (e.g.      */
+/* their own theming). Specificity is the right cascade tool here.          */
+.wk-list.wk-list,
+.wk-list.wk-list ol,
+.wk-list.wk-list ul {
+    margin-block: 0;
+}
+.wk-list.wk-list > li {
+    margin-block: 0;
+}
+.wk-list.wk-list-spacing-none > li + li { margin-top: 0; }
+.wk-list.wk-list-spacing-sm   > li + li { margin-top: 0.25rem; }
+.wk-list.wk-list-spacing-md   > li + li { margin-top: 0.5rem; }
+
 /* Accessibility: disable/shorten all WireKit animations & transitions for */
 /* users who request reduced motion (OS-level setting). Covers keyframe    */
 /* animations AND Alpine x-transition durations on WireKit components.     */
@@ -913,5 +939,13 @@
     [x-data*="wirekitImageCompare"],
     [x-data*="wirekitImageCompare"] * {
         transition: none !important;
+    }
+    /* wk-animate-* utility classes (driven by the wirekitAnimate Alpine    */
+    /* helper / <x-wirekit::reveal> wrapper). The 22 keyframe animations    */
+    /* keep their classes applied so the final-state is visible (animation- */
+    /* fill-mode: both), but duration collapses to 0.01ms so users with     */
+    /* prefers-reduced-motion see an instant snap-to-final, no motion.     */
+    [class*='wk-animate-'] {
+        animation-duration: 0.01ms !important;
     }
 }

--- a/dist/wirekit.esm.js
+++ b/dist/wirekit.esm.js
@@ -1,4 +1,4 @@
-/*! WireKit ESM v1.6.0 | MIT License | https://wirekit.app
+/*! WireKit ESM v1.6.1 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 function Vt(e){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:

--- a/dist/wirekit.js
+++ b/dist/wirekit.js
@@ -1,4 +1,4 @@
-/*! WireKit v1.6.0 | MIT License | https://wirekit.app
+/*! WireKit v1.6.1 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 (()=>{function Vt(e){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:

--- a/resources/js/components/toast.js
+++ b/resources/js/components/toast.js
@@ -31,7 +31,7 @@ export default function wirekitToast(config = {}) {
             // only events whose dispatching element matches `closest(scope)`
             // are handled — useful for "per-section toast surfaces" where
             // multiple toast regions share the same event name but each
-            // owns a portion of the DOM tree (e.g. the docs-app live-preview
+            // owns a portion of the DOM tree (e.g. an embedded live-preview
             // pattern, or a real app with per-card local toast queues).
             //
             // Falsy / missing → no containment filter, every dispatched

--- a/resources/views/components/code-block.blade.php
+++ b/resources/views/components/code-block.blade.php
@@ -19,10 +19,10 @@
 
     // The wrapper supplies bg / border / radius. The inner <pre> + <code>
     // explicitly null those properties to neutralise generic prose
-    // stylesheets that target raw markdown code blocks (e.g. the docs-app's
-    // prose.css adds bg-white + radius + padding to every <pre>) — without
-    // this defence the consumer sees a white box nested inside our muted
-    // container.
+    // stylesheets that target raw markdown code blocks (e.g. a host
+    // prose.css that adds bg-white + radius + padding to every <pre>) —
+    // without this defence the consumer sees a white box nested inside
+    // our muted container.
     $preClasses = implode(' ', [
         'm-0 p-0',
         'bg-transparent border-0 rounded-none',

--- a/resources/views/components/data-list.blade.php
+++ b/resources/views/components/data-list.blade.php
@@ -8,8 +8,8 @@
 
     // Data list wraps native <dl> for semantic key-value pairs.
     // Layouts: horizontal (label left, value right), stacked, grid.
-    // Inline styles ensure layout works in docs-app where Tailwind JIT
-    // may not compile sm: responsive classes from vendor views.
+    // Inline styles ensure layout works on docs.wirekit.app where Tailwind
+    // JIT may not compile sm: responsive classes from vendor views.
     $layoutStyle = match ($layout) {
         'stacked' => 'display: flex; flex-direction: column; gap: 1rem;',
         'grid' => 'display: grid; grid-template-columns: repeat(2, 1fr); gap: 1rem;',

--- a/resources/views/components/data-list/item.blade.php
+++ b/resources/views/components/data-list/item.blade.php
@@ -7,8 +7,9 @@
     use Pushery\WireKit\WireKit;
 
     // Each item is a <dt>/<dd> pair displayed side-by-side.
-    // Uses inline styles for layout to guarantee rendering in docs-app
-    // where Tailwind JIT may not compile sm: responsive classes.
+    // Uses inline styles for layout to guarantee rendering on
+    // docs.wirekit.app where Tailwind JIT may not compile sm: responsive
+    // classes.
     $itemClasses = WireKit::resolveClasses('data-list', 'item', implode(' ', [
         'py-[var(--padding-wk-y-sm)]',
     ]), $scope);

--- a/resources/views/components/feature.blade.php
+++ b/resources/views/components/feature.blade.php
@@ -43,8 +43,8 @@
 
     // Size map → [chipDimensionClasses, iconSizeProp].
     // The icon size prop replaces the icon's default h-5 w-5 cleanly.
-    // xl is for hero-row features (64×64 chip, 32×32 icon) per the briefing's
-    // proposed scale; sm covers dense feature lists; md is the historical default.
+    // xl is for hero-row features (64×64 chip, 32×32 icon); sm covers dense
+    // feature lists; md is the historical default.
     $sizeMap = [
         'sm' => ['w-8 h-8 rounded-[var(--radius-wk-sm)]', 'sm'],
         'md' => ['w-10 h-10 rounded-[var(--radius-wk-md)]', 'md'],

--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -28,10 +28,14 @@
         ]),
     };
 
+    // wk-list-spacing-{sm|md|none} pairs with the CSS rules in wirekit.css
+    // that use `!important` to win over consumer typography wrappers
+    // (`.prose`, `.docs-prose`, etc.) which otherwise inject vertical
+    // margin into <ol>/<ul>/<li> and compound across nesting depth.
     $spacingClasses = match ($spacing) {
-        'none' => 'space-y-0',
-        'sm' => 'space-y-1',
-        'md' => 'space-y-2',
+        'none' => 'wk-list-spacing-none',
+        'sm' => 'wk-list-spacing-sm',
+        'md' => 'wk-list-spacing-md',
         default => WireKit::validateProp('list', 'spacing', $spacing, ['none', 'sm', 'md']),
     };
 
@@ -40,6 +44,11 @@
         'text-[var(--color-wk-text)]',
         'text-[length:var(--text-wk-md)]',
         'tracking-[var(--font-wk-letter-spacing)]',
+        // `wk-list` is the marker class that the wirekit.css override
+        // rules target. Resets browser-default + consumer typography
+        // margins on <ol>/<ul>/<li> so the spacing prop is the single
+        // source of truth for inter-item vertical rhythm at every depth.
+        'wk-list',
         $type !== 'none' ? 'pl-[var(--space-wk-lg,1.5rem)]' : '',
         $typeClasses,
         $spacingClasses,

--- a/src/Console/ExportBlocksCommand.php
+++ b/src/Console/ExportBlocksCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 
 /**
  * emit a `/blocks.json` machine-readable manifest of every
- * layout + blueprint with its frontmatter metadata. Consumed by the docs-app's
+ * layout + blueprint with its frontmatter metadata. Consumed by the docs site's
  * `/blocks` gallery UI for filterable browsing.
  *
  * Output shape:
@@ -126,7 +126,7 @@ class ExportBlocksCommand extends Command
                 'dependencies' => $frontmatter['dependencies'] ?? [],
                 'responsive' => $frontmatter['responsive'] ?? null,
                 'dark_compatible' => $frontmatter['dark_compatible'] ?? null,
-                // Surfaced so the docs-app can filter the gallery by per-request
+                // Surfaced so the docs site can filter the gallery by per-request
                 // session tier (guest sessions never see admin-only blocks).
                 'visibility' => $frontmatter['visibility'] ?? 'guest',
                 'draft' => $frontmatter['draft'] ?? false,

--- a/src/Console/ExportJsonCommand.php
+++ b/src/Console/ExportJsonCommand.php
@@ -13,10 +13,10 @@ use Pushery\WireKit\ComponentRegistry;
  * Emits a machine-readable manifest of every WireKit component, including
  * category, description, props (parsed from @props([...]) blocks in the
  * Blade file), and slot names (parsed from $slot / @isset($slotName)
- * references). Designed to be consumed by the docs-app's
+ * references). Designed to be consumed by the docs site's
  * /components.json endpoint, AI tooling, and design-system audits.
  *
- * The docs-app's wrapper (BuildComponentsJsonCommand) calls us twice:
+ * The docs site's wrapper (BuildComponentsJsonCommand) calls us twice:
  * once with --pretty, once without. We support both by accepting --pretty
  * and pretty-printing whenever it's set; without the flag we emit
  * minified JSON. Either way: stdout-only, exit 0 on success, JSON
@@ -77,7 +77,7 @@ class ExportJsonCommand extends Command
             return self::FAILURE;
         }
 
-        // Write to stdout — the docs-app captures whatever we emit and
+        // Write to stdout — the docs site captures whatever we emit and
         // serves it from /components.json. Use $this->line() with empty
         // verbosity guard so the JSON stays the only thing on stdout.
         $this->output->write($json);

--- a/src/Console/GenerateChangelogsCommand.php
+++ b/src/Console/GenerateChangelogsCommand.php
@@ -339,6 +339,84 @@ class GenerateChangelogsCommand extends Command
             // Cross-repo automation-actor mentions. `docs[-]agent` matches
             // the same string but defeats literal-substring grep.
             '~\s*\b(?:wirekit-docs\s+agent|docs[-]agent|agent)\b~i',
+            // Lowercase 'chunks N, M, P' enumerations — internal Plan/Chunk
+            // bookkeeping in commit subjects that escapes the singular-form
+            // pattern above. Catches 'chunks 2,5,6,7' / 'chunk 1, 3, 4'.
+            '~\s*\bchunks?\s+\d+(?:\s*,\s*\d+){1,}~i',
+            // Internal vendor↔consumer split scopes (e.g.
+            // `fix(vendor-side-workarounds): …`). Strip the parenthetical
+            // scope and any bare compound form in the subject body.
+            '~\s*\(vendor-side[-]\w+(?:[-]\w+)*\)~i',
+            '~\s*\bvendor-side[-]\w+(?:[-]\w+)*\b~i',
+            // Bookkeeping-style compound idioms — 'ship N source-fixes
+            // (chunks A,B,C)' / 'confirm N already-clean (A,B,C)' /
+            // 'acknowledge N keep-as-exception (A,B,C)'. Strip each whole
+            // compound greedily UP TO AND INCLUDING the optional '+ '
+            // connector that follows, so empty parens / orphan number
+            // lists / orphan '+' connectors never linger as residue.
+            '~\s*\bship\s+\d+\s+source[- ]fixes?\b[^+]*(?:\+\s*)?~i',
+            '~\s*\bconfirm\s+\d+\s+already[- ]clean\b[^+]*(?:\+\s*)?~i',
+            '~\s*\backnowledge\s+\d+\s+keep[- ]as[- ]exception\b[^+]*(?:\+\s*)?~i',
+            // Defensive fallbacks if the compound idiom appears in a
+            // different surrounding shape (defense in depth).
+            '~\s*\bsource-fixes?\b~i',
+            '~\s*\balready-clean\b~i',
+            '~\s*\bkeep-as-exception\b~i',
+            // Orphan empty parens '()' and pure-number paren lists
+            // '(1,3,4)' that may remain after the strips above.
+            '~\s*\(\s*\)~',
+            '~\s*\(\s*\d+(?:\s*,\s*\d+)*\s*\)~',
+            // Orphan '+' connectors that linger when both sides got
+            // stripped. Require whitespace on BOTH sides AND another
+            // orphan '+' or end-of-string in lookahead — avoids
+            // false-positives on adjacent literal '+' chars (e.g.
+            // a commit subject quoting "++8.4%" must keep both '+'s).
+            '~\s+\+(?=\s+\+|\s*$)~',
+            // Briefing-system / field-testing idioms. The briefing system
+            // is internal cross-repo communication; 'field-test brief' /
+            // 'consumer-polish wave' / 'downstream landing-page rebuild'
+            // betray the agent-driven development workflow.
+            '~\s*\bbriefing\b[\w\s-]*~i',
+            '~\s*\bconsumer-polish\s+wave\b~i',
+            '~\s*\bfield[- ]test(?:ing|ed|s)?\s+(?:brief|wave|window)?~i',
+            '~\s*\bclosing[- ]loop\s+ack\b~i',
+            // Internal codename for docs.wirekit.app.
+            '~\s*\bdocs-app\b~i',
+            // Internal scope name: '(public-surface)' as commit scope reveals
+            // the internal vendor↔consumer split language. Strip the parens
+            // form; bare 'public surface' as English prose is fine.
+            '~\s*\(public[- ]surface\)~i',
+            // Compound phrase patterns — strip the whole bookkeeping shape
+            // BEFORE narrow word-strips destroy the surrounding context.
+            // Order matters: most-specific compound first, narrow word-strip
+            // last as a defensive fallback.
+            //
+            // 'close N internal-jargon leaks' — verb + count + meta-internal
+            // compound + leaks-noun. Strip the whole shape AND the trailing
+            // ' + N enforcement layers' bookkeeping (greedy through the '+').
+            '~\s*\bclose\s+\d+\s+internal[- ]jargon(?:\s+leaks?)?(?:\s*\+\s*\d+\s+enforcement\s+layers?)?\b~i',
+            // 'remove ALL internal Plan/Chunk/ leaks from PUBLIC files' /
+            // similar phrasings — describes the bug-class being fixed but
+            // reveals the Plan/Chunk system itself. Strip whole body.
+            '~\s*\bremove\s+(?:ALL\s+)?internal\s+Plan/Chunk[/\s][^.]*~i',
+            '~\s*\bPlan/Chunk\b[/\s\w]*\bleaks?\b[^.]*~i',
+            '~\s*\bPlan/Chunk[/\s]+~i',
+            // Defensive fallbacks — narrower word-strips that catch any
+            // remnant after the compound strip above ran.
+            '~\s*\binternal[- ]jargon(?:\s+leaks?)?\b~i',
+            '~\s*\+?\s*\d+\s+enforcement\s+layers?\b~i',
+            '~\s*\bclose\s+\d+\s+\w+(?:[-]\w+)*\s+leaks?\b[^+.]*~i',
+            // Briefing-retrospective phrasing — 'brief from', 'downstream
+            // landing-page rebuild' / 'downstream brief'. Reads as "I'm
+            // writing about a meeting we had", not user-facing prose.
+            '~\s*\b(?:the\s+)?brief\s+from\b[\w\s-]*~i',
+            '~\s*\bdownstream\s+(?:brief|landing[- ]page|rebuild|build)\b[^.]*~i',
+            '~\s*\b(?:brief|briefing)\s+(?:flagged|reported|captured)\b[^.]*~i',
+            '~\s*\bcaught\s+at\s+user\s+QA\b~i',
+            // Internal version markers (e.g. 'post-1.5.0') used in headings
+            // / parentheticals to communicate "released after vX.Y.Z".
+            '~\s*\(\s*post-[1-9]\.\d+(?:\.\d+)?\s*\)~i',
+            '~\s*\bpost-[1-9]\.\d+(?:\.\d+)?\b~i',
         ];
 
         $clean = preg_replace($patterns, '', $subject);
@@ -356,6 +434,16 @@ class GenerateChangelogsCommand extends Command
         // class matches the whole codepoint atomically.
         $clean = preg_replace('/^((?:feat|fix|refactor|perf|a11y|security)(?:\([^)]+\))?):\s*[\x{2014}\x{2013}\-]\s*/u', '$1: ', (string) $clean);
         $clean = trim((string) $clean, " \t\n.,;:");
+
+        // If after every strip-pass the only thing left is a bare verb
+        // prefix ('fix', 'feat', 'refactor', 'perf', 'a11y', 'security')
+        // — optionally with a scope — treat the bullet as content-empty
+        // so the caller drops it. The original commit body was nothing
+        // BUT internal jargon; emitting `- fix` as the public-facing
+        // changelog line is worse than emitting nothing.
+        if (preg_match('~^(?:feat|fix|refactor|perf|a11y|security)(?:\s*\([^)]*\))?\s*:?\s*$~i', (string) $clean)) {
+            return '';
+        }
 
         return $clean;
     }

--- a/src/Sandbox/PropsValidator.php
+++ b/src/Sandbox/PropsValidator.php
@@ -64,7 +64,7 @@ final class PropsValidator
             $expectedType = (string) ($spec['type'] ?? 'string');
 
             // Coerce HTML-form-derived strings into their declared scalar
-            // types BEFORE the strict type check. Docs-app Sandbox `<select>`
+            // types BEFORE the strict type check. Sandbox `<select>`
             // / `<input type="number">` / `<input type="checkbox">` all send
             // string values over POST; without coercion, schemas with
             // `type: int` (e.g. heading.level) reject every form submission
@@ -95,6 +95,7 @@ final class PropsValidator
         return new ValidationResult($clean, $violations);
     }
 
+    /** mixed: accepts any PHP value — the purpose of this method is to check that ANY value satisfies a named type spec. */
     private static function typeMatches(mixed $value, string $expected): bool
     {
         return match ($expected) {
@@ -145,6 +146,7 @@ final class PropsValidator
     /**
      * @param  array<int, string>  $violations
      */
+    /** mixed: recursively sanitizes any PHP value (string, bool, int, float, null, array). */
     private static function sanitize(mixed $value, string $propName, array &$violations, int $depth = 0): mixed
     {
         if ($depth > self::MAX_ARRAY_DEPTH) {

--- a/src/Sandbox/RenderResult.php
+++ b/src/Sandbox/RenderResult.php
@@ -15,9 +15,10 @@ namespace Pushery\WireKit\Sandbox;
  *
  * Caller maps to HTTP status: 200 for success, 422 for rejection.
  *
- * Public-readable property contract — the wirekit-docs `SandboxController`
- * reads `ok`, `violations`, `html`, `schema` off the object via
- * `get_object_vars()`. Any rename here breaks the docs-app wrapper.
+ * Public-readable property contract — downstream consumers (e.g. the docs
+ * site's `SandboxController`) read `ok`, `violations`, `html`, `schema` off
+ * the object via `get_object_vars()`. Any rename here is a breaking change
+ * for those consumers.
  */
 final class RenderResult
 {


### PR DESCRIPTION

Patch release covering five consumer-visible fixes plus a README restructure and badge expansion. No new API surface; no breaking changes; every component renders byte-identical to v1.6.0 unless its specific bug applied.

### Fixed

- **`prefers-reduced-motion: reduce` now actually honored on `<x-wirekit::reveal>` and `wk-animate-*` utilities (WCAG 2.3.3).** The component documentation and helper docblock claimed the OS-level reduced-motion preference was respected, but the global `@media (prefers-reduced-motion: reduce)` block in `dist/wirekit.css` only gated `[x-transition]` selectors — the 22 keyframe animations driving every preset ran at full speed regardless of user preference. The block now gates `[class*='wk-animate-']` as well, snapping `animation-duration` to `0.01ms` so reduced-motion users see an instant snap-to-final state. Behavior now matches the documented contract.

- **Nested `<x-wirekit::list>` margins no longer accumulate inside typography wrappers.** When the component is rendered inside a consumer's `.prose` / `.docs-prose` / `@tailwindcss/typography` context, the wrapper's `<ol>` / `<ul>` / `<li>` rules injected `margin: 1em 0` onto every level — and the previous Tailwind-utility approach was too low-specificity to win the cascade. Nested lists looked progressively more spaced out at deeper levels regardless of the `spacing` prop. The component now ships with a `wk-list` marker class plus dedicated `wk-list-spacing-{none,sm,md}` rules in `dist/wirekit.css` whose doubled-class selectors win on specificity alone (no `!important`, so consumers can still override with even-higher-specificity rules when they explicitly need to). The `spacing` prop is now the single source of truth for inter-item vertical rhythm at every nesting depth.

- **`bounce` and `spring` reveal presets — final state no longer fades back to invisible.** The `wk-bounce-in` and `wk-spring-in` keyframes declared `opacity: 1` only at the 50% / 60% peaks; the 70% and 100% frames left opacity unspecified. With `animation-fill-mode: both`, some browser implementations held opacity at 1 from the last specified frame, but others interpolated back toward the underlying inline `opacity: 0` after the animation settled — the element became visible briefly, then vanished. All four `bounce` / `spring` keyframe blocks now declare `opacity` at every frame, so the final-state behavior is browser-independent.

- **Source-file comment cleanup.** PHP, Blade, and Alpine JS files in `src/`, `resources/views/`, and `resources/js/` no longer carry internal-only project terminology in their inline comments and strings. Consumer-facing source now uses consistent product-public language throughout. No functional changes to any component, command, or helper.

- **`wirekit:generate-changelogs` sanitizer — broader pattern coverage.** The codegen's commit-subject sanitizer (`GenerateChangelogsCommand::sanitizeSubject()`) now strips a wider set of internal-only phrasing before writing per-component changelog entries, plus a verb-prefix early-return that drops bullets which would otherwise reduce to bare verb stubs (`fix:`, `security:`, etc.). See the method docblock for the exhaustive pattern list.

### Changed

- **`README.md` restructured from a comprehensive standalone reference to a concise getting-started overview.** Installation walkthrough, Quick Start example, and the browser-support table are retained on the GitHub landing page; extended component tables and the customisation reference now live at docs.wirekit.app where they're searchable and link-rich. Net effect: the README acts as a 30-second "what is this and how do I install it" landing page; docs.wirekit.app remains the authoritative reference for everything else.

- **`README.md` badge row expanded from 3 to 11 badges across two visual rows.** Row 1 (project status): Packagist version, Total Downloads, GitHub Actions test status, MIT licence, GitHub Stars, component count. Row 2 (stack): PHP ≥ 8.4, Laravel 12+, Livewire 4+, Tailwind CSS v4, Alpine.js. The CI badge in particular gives evaluators an at-a-glance signal that the build is green on `main`. Component-count badge auto-validates against `ComponentRegistry` via a Pest sync guard so the displayed number can never drift from the actual registry size.

---
