### PR TITLE
Release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [1.6.2] — 2026-04-30
+
+Patch release covering three small surface-polish fixes spotted in the v1.6.1 README + docs walk. No new API surface; no breaking changes; every component renders byte-identical to v1.6.1.
+
+### Changed
+
+- **`README.md` — removed the "Tests" CI badge.** The badge URL pointed at `pushery/wirekit/actions/workflows/tests.yml`, but the public Packagist repo doesn't carry the test suite (`tests/` is `export-ignore` in `.gitattributes`), so the badge image returned 404 and rendered as broken on every README view. The actual test suite (1686 tests, all green) runs on the development repo. The badge will return in a future release once a public-facing CI surface exists; for now, removing the broken image is the honest choice.
+
+### Fixed
+
+- **`<x-wirekit::code-block>` copy-button cursor.** The toolbar copy button rendered without a `cursor: pointer` on hover, leaving keyboard / mouse users unsure whether it was clickable. Added `cursor-pointer` to the button class — hover state now signals interactivity unambiguously, matching every other interactive control in WireKit.
+
+- **`docs/cli/wirekit-doctor.md` — "Common failures and fixes" section restructured.** The four subsection headings previously embedded the literal doctor command output (with `⚠` / `i` glyphs and inline-code backticks at H3 size), which rendered awkwardly on docs.wirekit.app — small icons forced to heading scale, monospace at heading weight. Each subsection now uses a descriptive title (e.g. "Sans font mismatch") and quotes the exact doctor line in a `text` code block in the body. Reads cleanly at every viewport.
+
+---
+
 ## [1.6.1] — 2026-04-30
 
 Patch release covering five consumer-visible fixes plus a README restructure and badge expansion. No new API surface; no breaking changes; every component renders byte-identical to v1.6.0 unless its specific bug applied.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/pushery/wirekit.svg)](https://packagist.org/packages/pushery/wirekit)
 [![Total Downloads](https://img.shields.io/packagist/dt/pushery/wirekit.svg)](https://packagist.org/packages/pushery/wirekit)
-[![Tests](https://github.com/pushery/wirekit/actions/workflows/tests.yml/badge.svg)](https://github.com/pushery/wirekit/actions/workflows/tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/pushery/wirekit?style=flat&logo=github)](https://github.com/pushery/wirekit/stargazers)
 [![Components](https://img.shields.io/badge/components-110-5046e5)](https://docs.wirekit.app/components)

--- a/dist/wirekit.core.js
+++ b/dist/wirekit.core.js
@@ -1,4 +1,4 @@
-/*! WireKit Core v1.6.1 | MIT License | https://wirekit.app */
+/*! WireKit Core v1.6.2 | MIT License | https://wirekit.app */
 (()=>{function d(a){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:
   npm install chart.js
 And import it in your app.js:

--- a/dist/wirekit.css
+++ b/dist/wirekit.css
@@ -1,5 +1,5 @@
 /*!
- * WireKit CSS v1.6.1 — MIT License
+ * WireKit CSS v1.6.2 — MIT License
  * https://github.com/pushery/wirekit
  * https://wirekit.app
  *

--- a/dist/wirekit.esm.js
+++ b/dist/wirekit.esm.js
@@ -1,4 +1,4 @@
-/*! WireKit ESM v1.6.1 | MIT License | https://wirekit.app
+/*! WireKit ESM v1.6.2 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 function Vt(e){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:

--- a/dist/wirekit.js
+++ b/dist/wirekit.js
@@ -1,4 +1,4 @@
-/*! WireKit v1.6.1 | MIT License | https://wirekit.app
+/*! WireKit v1.6.2 | MIT License | https://wirekit.app
  * Bundled: @floating-ui/dom ^1.7.0 (MIT), @floating-ui/core ^1.7.0 (MIT),
  *          focus-trap ^8.0.0 (MIT), tabbable ^6.0.0 (MIT) */
 (()=>{function Vt(e){return{chart:null,_navCleanup:null,_darkModeObserver:null,_darkModeDebounce:null,_manualColorIndices:new Set,init(){if(typeof Chart>"u"){console.error(`WireKit: Chart.js is not loaded. Install it via npm:

--- a/resources/views/components/code-block.blade.php
+++ b/resources/views/components/code-block.blade.php
@@ -69,7 +69,7 @@
                                 setTimeout(() => { srMessage = ''; }, 2000);
                             });
                     "
-                    class="text-[var(--color-wk-text-muted)] hover:text-[var(--color-wk-text)] transition-colors p-1"
+                    class="cursor-pointer text-[var(--color-wk-text-muted)] hover:text-[var(--color-wk-text)] transition-colors p-1"
                     aria-label="Copy to clipboard"
                     :aria-label="copied ? 'Copied to clipboard' : 'Copy to clipboard'"
                 >


### PR DESCRIPTION

Patch release covering three small surface-polish fixes spotted in the v1.6.1 README + docs walk. No new API surface; no breaking changes; every component renders byte-identical to v1.6.1.

### Changed

- **`README.md` — removed the "Tests" CI badge.** The badge URL pointed at `pushery/wirekit/actions/workflows/tests.yml`, but the public Packagist repo doesn't carry the test suite (`tests/` is `export-ignore` in `.gitattributes`), so the badge image returned 404 and rendered as broken on every README view. The actual test suite (1686 tests, all green) runs on the development repo. The badge will return in a future release once a public-facing CI surface exists; for now, removing the broken image is the honest choice.

### Fixed

- **`<x-wirekit::code-block>` copy-button cursor.** The toolbar copy button rendered without a `cursor: pointer` on hover, leaving keyboard / mouse users unsure whether it was clickable. Added `cursor-pointer` to the button class — hover state now signals interactivity unambiguously, matching every other interactive control in WireKit.

- **`docs/cli/wirekit-doctor.md` — "Common failures and fixes" section restructured.** The four subsection headings previously embedded the literal doctor command output (with `⚠` / `i` glyphs and inline-code backticks at H3 size), which rendered awkwardly on docs.wirekit.app — small icons forced to heading scale, monospace at heading weight. Each subsection now uses a descriptive title (e.g. "Sans font mismatch") and quotes the exact doctor line in a `text` code block in the body. Reads cleanly at every viewport.

---
