### PR TITLE
Release v2.3.1

### DIFF
--- a/.cursor/rules/wirekit.mdc
+++ b/.cursor/rules/wirekit.mdc
@@ -28,7 +28,7 @@ with a double colon:
 NEVER use a single colon (`<x-wirekit:button>`) — that syntax does not
 resolve to the package's anonymous-component path.
 
-## Variant system (Plan 28)
+## Variant system
 
 Most interactive components support a unified Intent × Surface variant
 system. Acceptable values:
@@ -72,7 +72,7 @@ Common tokens:
 NEVER use the `dark:` Tailwind prefix on a WireKit component or its
 content — tokens auto-switch via the parent `.dark` class.
 
-## Icon usage (Plan 32 Chunk B2)
+## Icon usage
 
 ```blade
 <x-wirekit::icon name="check" size="sm" />
@@ -91,7 +91,7 @@ marketing-specific aliases. Configure in `config/wirekit.php`:
 'icons' => ['presets' => ['heroicons', 'heroicons-marketing']],
 ```
 
-## Layout primitives (Plan 28)
+## Layout primitives
 
 Reach for these instead of hand-rolled flex/grid:
 
@@ -104,7 +104,7 @@ Reach for these instead of hand-rolled flex/grid:
 - `<x-wirekit::aspect-ratio ratio="16/9">` — locked aspect ratio
 - `<x-wirekit::divider>`, `<x-wirekit::spacer size="md">`
 
-## Typography primitives (Plan 28)
+## Typography primitives
 
 ```blade
 <x-wirekit::heading level="2">Section title</x-wirekit::heading>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [2.3.1] — 2026-05-27
+
+Patch release.
+
+### Fixed
+
+- **`.cursor/rules/wirekit.mdc` section-heading polish.** Several headings have been simplified to cleaner product copy. Developers running `php artisan wirekit:cursor-rules` after `composer update` pick up the polished rules file.
+
+---
+
 ## [2.3.0] — 2026-05-26
 
 **Minor release.** First-time-integrator audit follow-up. Five surface areas touched: form-input accessibility (`multi-select`, `range-slider`), shared-prop-vocabulary aliases (`feature`, `card`, `button`, `heading`, `reveal`), icon-system completeness (8 new base aliases per preset + bare-name fallthrough resolution), new `main` max-width default + `button` `forceLoading`, two new artisan-command capabilities (`wirekit:show <parent>.<child>`, `wirekit:verify --fix`), plus a new static-analysis a11y linter `wirekit:doctor:a11y`. Documentation site grows the unified `/blueprints/` route with `/blueprints/partials/*` (8 marketing-section building blocks) and `/blueprints/recipes/*` (10 worked-example compositions) under a fresh index page.


### PR DESCRIPTION

Patch release.

### Fixed

- **`.cursor/rules/wirekit.mdc` section-heading polish.** Several headings have been simplified to cleaner product copy. Developers running `php artisan wirekit:cursor-rules` after `composer update` pick up the polished rules file.

---
